### PR TITLE
Migrate to rn-fetch-blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This storage can be used on Android to prevent issues with the storage limitatio
 yarn add redux-persist-filesystem-storage
 ```
 
-Then, as [react-native-fetch-blob](https://github.com/wkh237/react-native-fetch-blob) is a dependency of this project, we need to ensure its linked with
+Then, as [rn-fetch-blob](https://github.com/joltup/rn-fetch-blob) is a dependency of this project, we need to ensure its linked with
 ```
-react-native link react-native-fetch-blob
+react-native link rn-fetch-blob
 ```
-(or check [their docs](https://github.com/wkh237/react-native-fetch-blob#user-content-installation)).
+(or check [their docs](https://github.com/joltup/rn-fetch-blob#user-content-installation)).
 
 ## usage
 ```javascript

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 * @flow
 */
 
-import RNFetchBlob from 'react-native-fetch-blob'
+import RNFetchBlob from 'rn-fetch-blob'
 
 let options = {
   storagePath: `${RNFetchBlob.fs.dirs.DocumentDir}/persistStore`,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "Rob Walker",
   "license": "MIT",
   "dependencies": {
-    "react-native-fetch-blob": "^0.10.0"
+    "rn-fetch-blob": "^0.10.0"
   }
 }


### PR DESCRIPTION
Since the original react-native-fetch-blob has been abandoned, this pull request migrates the dependency to rn-fetch-blob, the newer fork that has taken over maintenance of it.