### PR TITLE
fix: getItem doesn't callback if file doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,28 +59,12 @@ const FilesystemStorage = {
             return data;
           }
         })
-        .catch(error =>
-          RNFetchBlob.fs
-            .exists(filePath)
-            .then(exists => {
-              if (exists) {
-                // The error is not related to the existence of the file
-                callback && callback(error);
-                if (!callback) {
-                  throw error;
-                }
-              }
-
-              return "";
-            })
-            .catch(() => {
-              // We throw the original error
-              callback && callback(error);
-              if (!callback) {
-                throw error;
-              }
-            })
-        );
+        .catch(error => {
+          callback && callback(error);
+          if (!callback) {
+            throw error;
+          }
+        });
     }
   ),
 


### PR DESCRIPTION
Fix the issue that `callback` in `getItem` is never called if the file doesn't exist.

It's a real issue that can produce an infinite waiting state in an application at first launch.

But that code I delete seems to be a wanted behavior from this commit : https://github.com/robwalkerco/redux-persist-filesystem-storage/commit/206c3666ace8ea1b2898c2d877ed5bc3a1fc424a so I also should ask to the author @TimRobinson1 : Why is this behavior exist ? Did I miss something ? Thank's.