### PR TITLE
Upgrade react-native-blob-util to support new architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "flow": "flow"
   },
   "dependencies": {
-    "react-native-blob-util": "^0.16.0"
+    "react-native-blob-util": "^0.18.0"
   },
   "devDependencies": {
     "flow-bin": "^0.108.0"


### PR DESCRIPTION
Please merge so that we can use redux-persist-filesystem-storage with new RN architecture.